### PR TITLE
Fix typo: data_management/preprocessing/download_dataset/culturax.py

### DIFF
--- a/data_management/README.md
+++ b/data_management/README.md
@@ -49,7 +49,7 @@ python -m preprocessing.download_dataset --dataset=c4 --split=train --output_bas
 CulturaX(日本語) のダウンロードをする場合
 
 ```sh
-python -m preprocessing.download_dataset --language=ja --dataset=culturaX --output_base=tmp/output --index_from=0 --index_to=5
+python -m preprocessing.download_dataset --language=ja --dataset=culturax --output_base=tmp/output --index_from=0 --index_to=5
 ```
 
 全日本語 mC4 をダウンロードする場合

--- a/data_management/preprocessing/download_dataset/culturax.py
+++ b/data_management/preprocessing/download_dataset/culturax.py
@@ -47,7 +47,7 @@ def __execute_download(
 def download_dataset(
     language: str, output_base: str = "output", index_from: int = 0, index_to: int = 0
 ) -> None:
-    """Download the specified C4 dataset from Hugging Face."""
+    """Download the specified CulturaX dataset from Hugging Face."""
     if index_from < 0:
         raise ValueError("index_from must be greater than or equal to 0")
     if index_to < index_from:


### PR DESCRIPTION
## 🏁 Outline

`data_management/preprocessing/download_dataset/culturax.py`に関するtypoを修正します。

（レビュー時に見逃していました :bow:）

## 📝 Description

- https://github.com/geniacllm/ucllm_nedo_prod/commit/7ae75872c26036e513508d3d09f8fafbafd82108: こちらは単なるtypo fixです
- https://github.com/geniacllm/ucllm_nedo_prod/commit/bae01510a3607655a3780b41292ab2818fbd1906: READMEのコマンド例では動作しなかったので修正しています（詳細はコミットログに記載しています）

## 🔗 References

<!-- 参考情報となるリンクなど -->

## ✅ Test

以下のコマンドで`data_management/tmp/output/datasets/culturax/`にjsonlファイルが作成されることを確認しました。

```
python -m preprocessing.download_dataset --language=ja --dataset=culturax --output_base=tmp/output --index_from=0 --index_to=0
```

<!-- Pull Request 作成者側で確認した項目 -->

## 🤔 Concern

<!-- 懸念点や不安な要素、わからなかったことなどがあれば -->
