### PR TITLE
feat: add random sampling script for Ask-LLM human eval task.

### DIFF
--- a/data_management/askllm/README.md
+++ b/data_management/askllm/README.md
@@ -1,20 +1,12 @@
 # Ask-LLM 関連リポジトリ
 
 - [Notion のタスク一覧](https://www.notion.so/matsuolab-geniac/Ask-LLM-52e8a59eb3d8474db3198ee5f7920353?pvs=4)
-- 人手によるスコアデータセットの作成
-  - [Notion のタスク](https://www.notion.so/matsuolab-geniac/2447de2b123e410cb8f9ab1bb4bde4d2?pvs=4)
-  - [Slack のスレッド](https://matsuokenllmcommunity.slack.com/archives/C06MZ27BEQ2/p1712157307815259)
+- 人手によるスコアデータセットの作成 [Notion](https://www.notion.so/matsuolab-geniac/2447de2b123e410cb8f9ab1bb4bde4d2?pvs=4), [Slack](https://matsuokenllmcommunity.slack.com/archives/C06MZ27BEQ2/p1712157307815259)
   - CulturaX データセットからランダムに n 件サンプリングして CSV ファイルに出力するスクリプト
     - [random_sampling_culturax.py](random_sampling_culturax.py)
-- プロンプトエンジニアリング(英語/日本語)
-  - [Notion のタスク](https://www.notion.so/matsuolab-geniac/50abbc7b9f8b476db94315d4a8c83f9d?pvs=4)
-  - [Slack のスレッド](https://matsuokenllmcommunity.slack.com/archives/C06MZ27BEQ2/p1712158456495559)
-- 元DSからサンプリングDSを作成するスクリプトの実装
-  - [Notion のタスク](https://www.notion.so/matsuolab-geniac/DS-DS-2f3ac045bc984d019559938cc8de0128?pvs=4)
-  - [Slack のスレッド](https://matsuokenllmcommunity.slack.com/archives/C06MZ27BEQ2/p1712068290842469)
-- 本PJで使用可能な既存LLMの調査(ライセンス, 利用規約等)
-  - [Notion のタスク](https://www.notion.so/matsuolab-geniac/PJ-LLM-1dae4a2994b7496783d4a2ea2175a629?pvs=4)
-  - [Slack のスレッド](https://matsuokenllmcommunity.slack.com/archives/C06MZ27BEQ2/p1712165299844339)
+- プロンプトエンジニアリング(英語/日本語) [Notion](https://www.notion.so/matsuolab-geniac/50abbc7b9f8b476db94315d4a8c83f9d?pvs=4), [Slack](https://matsuokenllmcommunity.slack.com/archives/C06MZ27BEQ2/p1712158456495559)
+- 元DSからサンプリングDSを作成するスクリプトの実装 [Notion](https://www.notion.so/matsuolab-geniac/DS-DS-2f3ac045bc984d019559938cc8de0128?pvs=4), [Slack](https://matsuokenllmcommunity.slack.com/archives/C06MZ27BEQ2/p1712068290842469)
+- 本PJで使用可能な既存LLMの調査(ライセンス, 利用規約等) [Notion](https://www.notion.so/matsuolab-geniac/PJ-LLM-1dae4a2994b7496783d4a2ea2175a629?pvs=4), [Slack](https://matsuokenllmcommunity.slack.com/archives/C06MZ27BEQ2/p1712165299844339)
 - 参考資料
   - Ask-LLM論文
     - [How to Train Data-Efficient LLMs. arXiv:2402.09668](https://arxiv.org/abs/2402.09668)

--- a/data_management/askllm/README.md
+++ b/data_management/askllm/README.md
@@ -1,0 +1,10 @@
+# Ask-LLM 関連リポジトリ
+
+- タスク一覧
+  - https://www.notion.so/matsuolab-geniac/Ask-LLM-52e8a59eb3d8474db3198ee5f7920353?pvs=4
+
+- 人手によるスコアデータセットの作成
+  - タスク
+    - https://www.notion.so/matsuolab-geniac/2447de2b123e410cb8f9ab1bb4bde4d2?pvs=4
+  - [`random_sampling.py`](random_sampling.py)
+    - CulturaX データセットからランダムに n 件サンプリングして CSV ファイルに出力するスクリプト

--- a/data_management/askllm/README.md
+++ b/data_management/askllm/README.md
@@ -1,10 +1,24 @@
 # Ask-LLM 関連リポジトリ
 
-- タスク一覧
-  - https://www.notion.so/matsuolab-geniac/Ask-LLM-52e8a59eb3d8474db3198ee5f7920353?pvs=4
-
+- [Notion のタスク一覧](https://www.notion.so/matsuolab-geniac/Ask-LLM-52e8a59eb3d8474db3198ee5f7920353?pvs=4)
 - 人手によるスコアデータセットの作成
-  - タスク
-    - https://www.notion.so/matsuolab-geniac/2447de2b123e410cb8f9ab1bb4bde4d2?pvs=4
-  - [`random_sampling_culturax.py`](random_sampling_culturax.py)
-    - CulturaX データセットからランダムに n 件サンプリングして CSV ファイルに出力するスクリプト
+  - [Notion のタスク](https://www.notion.so/matsuolab-geniac/2447de2b123e410cb8f9ab1bb4bde4d2?pvs=4)
+  - [Slack のスレッド](https://matsuokenllmcommunity.slack.com/archives/C06MZ27BEQ2/p1712157307815259)
+  - CulturaX データセットからランダムに n 件サンプリングして CSV ファイルに出力するスクリプト
+    - [random_sampling_culturax.py](random_sampling_culturax.py)
+- プロンプトエンジニアリング(英語/日本語)
+  - [Notion のタスク](https://www.notion.so/matsuolab-geniac/50abbc7b9f8b476db94315d4a8c83f9d?pvs=4)
+  - [Slack のスレッド](https://matsuokenllmcommunity.slack.com/archives/C06MZ27BEQ2/p1712158456495559)
+- 元DSからサンプリングDSを作成するスクリプトの実装
+  - [Notion のタスク](https://www.notion.so/matsuolab-geniac/DS-DS-2f3ac045bc984d019559938cc8de0128?pvs=4)
+  - [Slack のスレッド](https://matsuokenllmcommunity.slack.com/archives/C06MZ27BEQ2/p1712068290842469)
+- 本PJで使用可能な既存LLMの調査(ライセンス, 利用規約等)
+  - [Notion のタスク](https://www.notion.so/matsuolab-geniac/PJ-LLM-1dae4a2994b7496783d4a2ea2175a629?pvs=4)
+  - [Slack のスレッド](https://matsuokenllmcommunity.slack.com/archives/C06MZ27BEQ2/p1712165299844339)
+- 参考資料
+  - Ask-LLM論文
+    - [How to Train Data-Efficient LLMs. arXiv:2402.09668](https://arxiv.org/abs/2402.09668)
+  - Ask-LLM論文紹介スライド
+    - [Ask-LLM論文紹介: How to Train Data-Efficient LLMs](https://speakerdeck.com/s_ota/ask-llm-20240313)
+  - Ask-LLM 非公式実装
+    - [nano-askllm](https://github.com/susumuota/nano-askllm)

--- a/data_management/askllm/README.md
+++ b/data_management/askllm/README.md
@@ -6,5 +6,5 @@
 - 人手によるスコアデータセットの作成
   - タスク
     - https://www.notion.so/matsuolab-geniac/2447de2b123e410cb8f9ab1bb4bde4d2?pvs=4
-  - [`random_sampling.py`](random_sampling.py)
+  - [`random_sampling_culturax.py`](random_sampling_culturax.py)
     - CulturaX データセットからランダムに n 件サンプリングして CSV ファイルに出力するスクリプト

--- a/data_management/askllm/random_sampling_culturax.py
+++ b/data_management/askllm/random_sampling_culturax.py
@@ -1,0 +1,41 @@
+# randomly sample 50 texts from the CulturaX dataset
+# and output them as a CSV file.
+
+# pip install numpy datasets
+# python random_sampling_culturax.py > culturax_samples_50_seed_42.csv
+
+import csv
+import sys
+
+import numpy as np
+from datasets import load_dataset
+
+# TODO: command-line arguments?
+seed = 42
+num_samples = 50
+max_text_length = 50000  # limit for Google Sheets
+
+dataset = load_dataset(
+    "uonlp/CulturaX",
+    "ja",
+    split="train",
+    cache_dir="/persistentshare/storage/team_kumagai/datasets",
+)
+
+np.random.seed(seed)
+indices = np.arange(dataset.num_rows)  # num_rows is 111188475
+np.random.shuffle(indices)
+
+writer = csv.writer(sys.stdout)
+writer.writerow(["id", "text"])
+
+for index in indices[:num_samples]:
+    i = int(index)
+    text = dataset[i]["text"]
+    if len(text) > max_text_length:
+        sys.stderr.write(
+            f"Text at index {i} is too long ({len(text)} characters),"
+            f" truncating to {max_text_length} characters\n"
+        )
+        text = text[:max_text_length]
+    writer.writerow([i, text])


### PR DESCRIPTION
## 🏁 Outline

- CulturaX データセットからランダムに n 件サンプリングして CSV ファイルに出力するスクリプトの追加

## 📝 Description

- Ask-LLMの評価のための人手によるスコアデータセットを作成する際に、CulturaX データセットからランダムに n 件サンプリングして CSV ファイルに出力するスクリプトが必要

## 🔗 References

- [Notion](https://www.notion.so/matsuolab-geniac/2447de2b123e410cb8f9ab1bb4bde4d2?pvs=4)
- [Slack](https://matsuokenllmcommunity.slack.com/archives/C06MZ27BEQ2/p1712157307815259)

## ✅ Test

- 松尾研プレ環境において正常実行できることを確認(メモリ不足で落ちない)
- 生成された CSV が Google スプレッドシートに正常インポート可能であることを確認
  - Google スプレッドシートのセルの最大文字数が50000文字で、それを超えるデータがあるとそのセルは空白となるが、スクリプトで50000文字で制限し空白にならないことを確認

## 🤔 Concern

- コマンドラインオプションをつけることも可能だが、2, 3 回程度しか実行しないので適宜パラメータを書き換えて実行することにした
