### PR TITLE
add MaskPersonNamesJa filter

### DIFF
--- a/data_management/preprocessing/filtering/__main__.py
+++ b/data_management/preprocessing/filtering/__main__.py
@@ -21,6 +21,7 @@ def process_json_lines(lines: list[str], output_base: str, stats: list[dict]):
             document_filters.DiscardAds(),
             document_filters.DiscardDiscriminationContentJa(),
             custom_document_filters.DiscardAdultContentJa(),
+            custom_document_filters.MaskPersonNamesJa(),
             custom_tokenization.NewLineSentenceTokenizer(),
             custom_token_filters.RemoveOneword(),
             custom_tokenization.MergeTokens(delimiter="\n"),

--- a/data_management/preprocessing/filtering/custom_document_filters.py
+++ b/data_management/preprocessing/filtering/custom_document_filters.py
@@ -65,21 +65,21 @@ class MaskPersonNamesJa(Filter):
             else:
                 masked_parsed_word_list.append(
                     "[MASKED]"
-                )  # TODO: 置換文字列を引数で指定できるようにした方が良い？
+                )  # 人名の部分を"[MASKED]"で置換
         masked_text = "".join(masked_parsed_word_list)
 
-        # faker_jp でマスク箇所を適当な人名に置換する
-        masked_fullname_pattern = re.compile(r"\[MASKED\]\[MASKED\]")
+        # faker_jp でマスク箇所を適当な人名に置換するためのパターンを定義
+        masked_fullname_pattern = re.compile(r"(\[MASKED\]){2,}")
         masked_single_name_pattern = re.compile(r"\[MASKED\]")
 
-        # [MASKED][MASKED] は姓と名の組み合わせと見做し、それぞれ適当な名前に置換する
+        # "[MASKED][MASKED]..."のように2回以上連続する場合はフルネームと見做し、適当な名前に置換する
         masked_text = re.sub(
             masked_fullname_pattern,
             faker_jp.name(),
             masked_text,
         )
 
-        # [MASKED] は名前の一部と見做し、適当な苗字に置換する
+        # "[MASKED]"が1回のみの場合は名前の一部と見做し、適当な苗字に置換する
         masked_text = re.sub(
             masked_single_name_pattern,
             faker_jp.last_name(),

--- a/data_management/requirements.txt
+++ b/data_management/requirements.txt
@@ -5,6 +5,7 @@ certifi==2024.2.2
 charset-normalizer==3.3.2
 dill==0.3.8
 docopt==0.6.2
+Faker==24.14.1
 filelock==3.13.1
 frozenlist==1.4.1
 fsspec==2023.10.0


### PR DESCRIPTION
## 🏁 Outline
人名をマスキングするフィルターの追加

## 📝 Description
custom_document_filtersにMaskPersonNamesJaというFilterを追加
人名のマスキングは簡易的にfugashiによる形態素解析の結果に基づいたものを実装

追記：2024/05/3
[faker](https://faker.readthedocs.io/en/master/)を使用した人名の置換を追加した。
流れとしては以下の通り。
1. fugashiの形態素解析の結果、人名に相当する単語を`[MASKED]`に置き換える。
2. 以下のルールに従い、1.でマスキングした箇所をランダムに生成された人名に置き換える。
- `[MASKED][MASKED]...` -> フルネームとみなし`苗字`+`名前`に置き換える。
- `[MASKED]` -> 苗字のみとみなし`苗字`に置き換える。


国会議事録のデータに対するマスキング例

- マスキング前
```text
"国務大臣の演説に対する質疑に入ります。泉健太君。\n    〔泉健太君登壇〕"
```

- マスキング(+その他フィルタリング)
```
"国務大臣の演説に対する質疑に入ります。[MASKED][MASKED]君。〔[MASKED][MASKED]君登壇〕"
```

- fakerによる置換
```
"国務大臣の演説に対する質疑に入ります。林千代君。〔林千代君登壇〕"
```


## 🔗 References
- Hojichar
https://github.com/HojiChar/HojiChar/blob/v0.9.0/hojichar/filters/document_filters.py

- fugashi
https://github.com/polm/fugashi

## ✅ Test
下記フィルタリングのスクリプト実行が問題なく行われることを確認。
```
cd data_management
python -m preprocessing.filtering --input_dir=$INPUT_DIR --output_dir=$OUTPUT_DIR
```


## 🤔 Concern

- マスキング後の文字列はどのようにするのが適切か？

